### PR TITLE
fix: remove unused PrismaModule from TarotModule

### DIFF
--- a/src/modules/tarot.module.ts
+++ b/src/modules/tarot.module.ts
@@ -2,10 +2,9 @@ import { Module } from '@nestjs/common';
 import { TarotController } from 'src/controllers/tarot.controller';
 import { OpenAIModule } from './openai.module';
 import { TarotService } from 'src/services/tarot.service';
-import { PrismaModule } from './prisma.module';
 
 @Module({
-  imports: [OpenAIModule, PrismaModule],
+  imports: [OpenAIModule],
   controllers: [TarotController],
   providers: [TarotService],
 })


### PR DESCRIPTION
## Summary
- TarotModule에서 더 이상 사용하지 않는 PrismaModule import 제거
- TarotService가 DB 작업을 하지 않게 되면서 불필요해짐

## Test plan
- [x] `npm run build` 통과
- [x] `npm test` 통과
- [x] `npm run lint` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)