### PR TITLE
refactor: change tarot read endpoint from POST to GET

### DIFF
--- a/src/controllers/tarot.controller.spec.ts
+++ b/src/controllers/tarot.controller.spec.ts
@@ -18,12 +18,7 @@ describe('TarotController', () => {
           useValue: mockTarotService,
         },
       ],
-    })
-      .overridePipe('ZodValidationPipe')
-      .useValue({
-        transform: (value: unknown) => value,
-      })
-      .compile();
+    }).compile();
 
     controller = module.get<TarotController>(TarotController);
   });
@@ -47,7 +42,7 @@ describe('TarotController', () => {
 
       mockTarotService.readTarot.mockResolvedValue(mockResponse);
 
-      const result = await controller.readTarot({});
+      const result = await controller.readTarot();
 
       expect(mockTarotService.readTarot).toHaveBeenCalledWith();
       expect(result).toEqual({

--- a/src/controllers/tarot.controller.ts
+++ b/src/controllers/tarot.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, HttpCode, Post } from '@nestjs/common';
+import { Controller, Get } from '@nestjs/common';
 import { ResponseData } from 'src/interfaces/response.interface';
 import { ReadResponse } from 'src/schemas/service/read.schema';
 import { TarotService } from 'src/services/tarot.service';
@@ -7,8 +7,7 @@ import { TarotService } from 'src/services/tarot.service';
 export class TarotController {
   constructor(private readonly tarotService: TarotService) {}
 
-  @Post('read')
-  @HttpCode(200)
+  @Get('read')
   async readTarot(): Promise<ResponseData<ReadResponse>> {
     const result = await this.tarotService.readTarot();
     return {

--- a/src/modules/tarot.module.ts
+++ b/src/modules/tarot.module.ts
@@ -2,10 +2,9 @@ import { Module } from '@nestjs/common';
 import { TarotController } from 'src/controllers/tarot.controller';
 import { OpenAIModule } from './openai.module';
 import { TarotService } from 'src/services/tarot.service';
-import { PrismaModule } from './prisma.module';
 
 @Module({
-  imports: [OpenAIModule, PrismaModule],
+  imports: [OpenAIModule],
   controllers: [TarotController],
   providers: [TarotService],
 })

--- a/src/schemas/service/read.schema.ts
+++ b/src/schemas/service/read.schema.ts
@@ -8,8 +8,3 @@ export const readResponseSchema = z.object({
 });
 
 export type ReadResponse = z.infer<typeof readResponseSchema>;
-
-// 요청 없음 - 서버에서 랜덤 카드/키워드 선택
-export const readRequestSchema = z.object({});
-
-export type ReadRequest = z.infer<typeof readRequestSchema>;


### PR DESCRIPTION
## Summary
- `POST /tarot/read` → `GET /tarot/read`
- 요청 body가 없으므로 GET이 더 적절
- 불필요한 request schema 제거
- 테스트 파일 정리

## Test plan
- [x] `npm run build` 통과
- [x] `npm test` 통과
- [x] `npm run lint` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)