### PR TITLE
feat: add configurable CORS settings

### DIFF
--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -30,6 +30,9 @@ config:
   server:
     nodeEnv: "production"
     port: 3000
+    corsOrigins:
+      - "*"
+    corsCredentials: true
   openai:
     existingSecret: ""  # External secret for openai secrets
     existingSecretKeys:

--- a/src/config/yaml.schema.ts
+++ b/src/config/yaml.schema.ts
@@ -27,6 +27,8 @@ export const yamlSchema = z.object({
       .refine((x) => ['development', 'production', 'test'].includes(x))
       .default('development'),
     port: z.number().int().positive().default(3000),
+    corsOrigins: z.array(z.string()).default(['*']),
+    corsCredentials: z.boolean().default(true),
   }),
   openai: z.object({
     apiKey: z.string().optional(),

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,10 @@ async function bootstrap() {
   const configService = app.get(ConfigService<Config, true>);
   const config = configService.get('server', { infer: true });
 
-  app.enableCors();
+  app.enableCors({
+    origin: config.corsOrigins.includes('*') ? true : config.corsOrigins,
+    credentials: config.corsCredentials,
+  });
 
   await app.listen(config.port);
 


### PR DESCRIPTION
## Summary
- CORS origins와 credentials를 YAML config에서 설정 가능하도록 변경
- `corsOrigins` 배열로 허용할 도메인 지정 (`*` 사용 시 모든 도메인 허용)
- `corsCredentials`로 쿠키/인증헤더 허용 여부 제어

## Test plan
- [ ] 로컬에서 config.yaml에 CORS 설정 후 서버 시작
- [ ] 허용된 도메인에서 API 요청 시 정상 응답 확인
- [ ] 허용되지 않은 도메인에서 CORS 에러 발생 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)