### PR TITLE
refactor: remove title/titleKR from LLM response schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ sequenceDiagram
         Cache-->>Service: Cached Result
     else Cache Miss
         Service->>AI: Chat Completion (with Zod schema)
-        AI-->>Service: {title, titleKR, keywords, advice}
+        AI-->>Service: {keywords, advice}
+        Service->>Service: Inject card.name / card.nameKR
         Service->>Cache: SET tarot:read:{card}:{dir}:{bucket}
     end
 

--- a/src/config/yaml.schema.ts
+++ b/src/config/yaml.schema.ts
@@ -37,10 +37,6 @@ export const yamlSchema = z.object({
         .string()
         .default(
           '주어지는 카드에 대하여 타로 메시지를 서술해줘.' +
-            '응답은 반드시 다음 JSON 형식을 따라야 해:' +
-            '{ title: string, titleKR: string, keywords: string[], advice: string }' +
-            'title은 카드의 영어 이름, titleKR은 카드의 한글 이름, ' +
-            'keywords는 4개의 키워드 배열, advice는 조언 메시지.' +
             commonSystemMessage,
         ),
     }),
@@ -90,7 +86,13 @@ export const yamlSchema = z.object({
       enabled: true,
       ttl: 3600,
       randomBucketSize: 10,
-      valkey: { host: 'valkey', port: 6379, db: 0, prefix: undefined, username: undefined },
+      valkey: {
+        host: 'valkey',
+        port: 6379,
+        db: 0,
+        prefix: undefined,
+        username: undefined,
+      },
     }),
 });
 

--- a/src/schemas/service/read.schema.ts
+++ b/src/schemas/service/read.schema.ts
@@ -1,5 +1,12 @@
 import { z } from 'zod';
 
+export const llmReadResponseSchema = z.object({
+  keywords: z.array(z.string()).length(4),
+  advice: z.string().min(1),
+});
+
+export type LlmReadResponse = z.infer<typeof llmReadResponseSchema>;
+
 export const readResponseSchema = z.object({
   title: z.string().min(1),
   titleKR: z.string().min(1),

--- a/src/services/openai.service.ts
+++ b/src/services/openai.service.ts
@@ -4,8 +4,8 @@ import OpenAI from 'openai';
 import { zodResponseFormat } from 'openai/helpers/zod';
 import type { ChatModel } from 'openai/resources';
 import type { Config } from 'src/config/config.schema';
-import type { ReadResponse } from 'src/schemas/service/read.schema';
-import { readResponseSchema } from 'src/schemas/service/read.schema';
+import type { LlmReadResponse } from 'src/schemas/service/read.schema';
+import { llmReadResponseSchema } from 'src/schemas/service/read.schema';
 import type { TarotCard } from 'src/services/tarot.service';
 
 interface TarotMessageRequest {
@@ -36,7 +36,9 @@ export class OpenAIService {
    * @param request TarotMessageRequest
    * @returns ReadResponse
    */
-  async getTarotMessage(request: TarotMessageRequest): Promise<ReadResponse> {
+  async getTarotMessage(
+    request: TarotMessageRequest,
+  ): Promise<LlmReadResponse> {
     const directionText = request.direction === 'upright' ? '정방향' : '역방향';
 
     const response = await this.openAI.chat.completions.parse({
@@ -56,7 +58,7 @@ export class OpenAIService {
           }),
         },
       ],
-      response_format: zodResponseFormat(readResponseSchema, 'ReadResponse'),
+      response_format: zodResponseFormat(llmReadResponseSchema, 'ReadResponse'),
     });
 
     if (!response.choices[0].message.parsed) {

--- a/src/services/tarot.service.ts
+++ b/src/services/tarot.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { OpenAIService } from './openai.service';
 import { ValkeyService } from './valkey.service';
-import { ReadResponse } from 'src/schemas/service/read.schema';
+import type { ReadResponse } from 'src/schemas/service/read.schema';
 import type { Config } from 'src/config/config.schema';
 
 export interface TarotCard {
@@ -103,11 +103,18 @@ export class TarotService {
     }
 
     const keywords = this.getRandomKeywords(4);
-    const result = await this.openAIService.getTarotMessage({
+    const llmResult = await this.openAIService.getTarotMessage({
       card,
       direction,
       keywords,
     });
+
+    const result: ReadResponse = {
+      title: card.name,
+      titleKR: card.nameKR,
+      keywords: llmResult.keywords,
+      advice: llmResult.advice,
+    };
 
     if (this.valkeyService.isEnabled()) {
       await this.valkeyService.set(cacheKey, JSON.stringify(result));

--- a/src/services/valkey.service.ts
+++ b/src/services/valkey.service.ts
@@ -24,7 +24,8 @@ export class ValkeyService implements OnModuleInit, OnModuleDestroy {
       return;
     }
 
-    const { host, port, password, db, prefix, username } = this.cacheConfig.valkey;
+    const { host, port, password, db, prefix, username } =
+      this.cacheConfig.valkey;
 
     this.client = new Redis({
       host,


### PR DESCRIPTION
- Add separate llmReadResponseSchema with keywords (length 4) and advice
- Inject canonical card.name and card.nameKR in TarotService
- Drop redundant JSON format instructions from system prompt
- Rely on zodResponseFormat for structured output enforcement
- Update README sequence diagram to reflect new data flow